### PR TITLE
Remove "vendor/bin" from every script path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,17 +43,17 @@
         "bin/phpqt-install"
     ],
     "scripts": {
-        "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
+        "test": "phpunit",
+        "test-coverage": "phpunit --coverage-html coverage",
         "inspect": [
-            "vendor/bin/phpcs src",
-            "vendor/bin/phpstan analyze src"
+            "phpcs src",
+            "phpstan analyze src"
         ],
         "inspect-fix": [
-            "vendor/bin/php-cs-fixer fix src",
-            "vendor/bin/phpcbf src"
+            "php-cs-fixer fix src",
+            "phpcbf src"
         ],
-        "insights": "vendor/bin/phpmd src text phpmd.xml"
+        "insights": "phpmd src text phpmd.xml"
     },
     "config": {
         "sort-packages": true

--- a/src/PhpQualityTools.php
+++ b/src/PhpQualityTools.php
@@ -84,14 +84,14 @@ class PhpQualityTools
     {
         return [
             "inspect" => [
-                sprintf("vendor/bin/phpcs %s", $this->srcDirectory),
-                sprintf("vendor/bin/phpstan analyze %s", $this->srcDirectory)
+                sprintf("phpcs %s", $this->srcDirectory),
+                sprintf("phpstan analyze %s", $this->srcDirectory)
             ],
             "inspect-fix" => [
-                sprintf("vendor/bin/php-cs-fixer fix %s", $this->srcDirectory),
-                sprintf("vendor/bin/phpcbf %s", $this->srcDirectory)
+                sprintf("php-cs-fixer fix %s", $this->srcDirectory),
+                sprintf("phpcbf %s", $this->srcDirectory)
             ],
-            "insights" => sprintf("vendor/bin/phpmd %s text phpmd.xml", $this->srcDirectory)
+            "insights" => sprintf("phpmd %s text phpmd.xml", $this->srcDirectory)
         ];
     }
 

--- a/tests/expected/composer.json
+++ b/tests/expected/composer.json
@@ -37,17 +37,17 @@
   },
   "bin": ["bin/phpqt-install"],
   "scripts": {
-    "test": "vendor/bin/phpunit",
-    "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
+    "test": "phpunit",
+    "test-coverage": "phpunit --coverage-html coverage",
     "inspect": [
-      "vendor/bin/phpcs src",
-      "vendor/bin/phpstan analyze src"
+      "phpcs src",
+      "phpstan analyze src"
     ],
     "inspect-fix": [
-      "vendor/bin/php-cs-fixer fix src",
-      "vendor/bin/phpcbf src"
+      "php-cs-fixer fix src",
+      "phpcbf src"
     ],
-    "insights": "vendor/bin/phpmd src text phpmd.xml"
+    "insights": "phpmd src text phpmd.xml"
   },
   "config": {
     "sort-packages": true

--- a/tests/expected/composer_no_script.json
+++ b/tests/expected/composer_no_script.json
@@ -38,14 +38,14 @@
   "bin": ["bin/phpqt-install"],
   "scripts": {
     "inspect": [
-      "vendor/bin/phpcs src",
-      "vendor/bin/phpstan analyze src"
+      "phpcs src",
+      "phpstan analyze src"
     ],
     "inspect-fix": [
-      "vendor/bin/php-cs-fixer fix src",
-      "vendor/bin/phpcbf src"
+      "php-cs-fixer fix src",
+      "phpcbf src"
     ],
-    "insights": "vendor/bin/phpmd src text phpmd.xml"
+    "insights": "phpmd src text phpmd.xml"
   },
   "config": {
     "sort-packages": true

--- a/tests/resources/composer.json
+++ b/tests/resources/composer.json
@@ -37,8 +37,8 @@
     },
     "bin": ["bin/phpqt-install"],
     "scripts": {
-        "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+        "test": "phpunit",
+        "test-coverage": "phpunit --coverage-html coverage"
 
     },
     "config": {


### PR DESCRIPTION
This is the PR adressing #5, in which i have removed every "vendor/bin" i could find.

Note that tests are still failing on Windows, because of the `composer.json`'s `bin` section. This may be a Composer issue, however...

Feel free to expand on this if i have missed something.